### PR TITLE
Use colors from Modrinth API

### DIFF
--- a/Asterion.Test/Asterion.Test.csproj
+++ b/Asterion.Test/Asterion.Test.csproj
@@ -16,7 +16,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-        <PackageReference Include="Modrinth.Net" Version="3.0.1" />
+        <PackageReference Include="Modrinth.Net" Version="3.0.3" />
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
         <PackageReference Include="NUnit.Analyzers" Version="3.5.0">

--- a/Asterion/Asterion.csproj
+++ b/Asterion/Asterion.csproj
@@ -17,10 +17,10 @@
       <PackageReference Include="Discord.Net.Core" Version="3.8.1" />
       <PackageReference Include="Fergun.Interactive" Version="1.6.0" />
       <PackageReference Include="Humanizer.Core" Version="2.14.1" />
-      <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.1" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.1" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.1" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.1">
+      <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.3" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.3" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.3" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.3">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
@@ -29,7 +29,7 @@
       <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0" />
-      <PackageReference Include="Modrinth.Net" Version="3.0.1" />
+      <PackageReference Include="Modrinth.Net" Version="3.0.3" />
       <PackageReference Include="Serilog" Version="2.12.0" />
       <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
       <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />

--- a/Asterion/EmbedBuilders/ModrinthEmbedBuilder.cs
+++ b/Asterion/EmbedBuilders/ModrinthEmbedBuilder.cs
@@ -89,7 +89,7 @@ public static class ModrinthEmbedBuilder
 
     public static EmbedBuilder GetProjectEmbed(SearchResult<ProjectDto> searchResult, IEnumerable<TeamMember>? teamMembers = null)
     {
-        return GetProjectEmbed(searchResult.Payload.Project, searchResult.Payload.MajorColor, teamMembers);
+        return GetProjectEmbed(searchResult.Payload.Project, teamMembers);
     }
 
     /// <summary>
@@ -99,7 +99,7 @@ public static class ModrinthEmbedBuilder
     /// <param name="majorColor"></param>
     /// <param name="teamMembers">Members of the team for this project, not required, if not provided, will show generic Modrinth Author</param>
     /// <returns>Embed builder, which can be further edited</returns>
-    public static EmbedBuilder GetProjectEmbed(Project project, Color majorColor, IEnumerable<TeamMember>? teamMembers = null, DateTimeOffset? dataTime = null)
+    public static EmbedBuilder GetProjectEmbed(Project project, IEnumerable<TeamMember>? teamMembers = null, DateTimeOffset? dataTime = null)
     {
         var author = GetEmbedAuthor(project, teamMembers);
         
@@ -111,7 +111,7 @@ public static class ModrinthEmbedBuilder
             Description = project.Description,
             ThumbnailUrl = project.IconUrl,
             // No icon, no major color, use Modrinth's color
-            Color = string.IsNullOrEmpty(project.IconUrl) ? ModrinthColor : majorColor,
+            Color = project.Color is null ? ModrinthColor : project.Color.Value.ToDiscordColor(),
             Fields = new List<EmbedFieldBuilder?>
             {
                 // Format downloads from 319803 to 319,8K 

--- a/Asterion/Extensions/ColorExtensions.cs
+++ b/Asterion/Extensions/ColorExtensions.cs
@@ -1,0 +1,11 @@
+using Discord;
+
+namespace Asterion.Extensions;
+
+public static class ColorExtensions
+{
+    public static Discord.Color ToDiscordColor(this System.Drawing.Color color)
+    {
+        return new Color(color.R, color.G, color.B);
+    }
+}

--- a/Asterion/Services/Modrinth/ModrinthService.cs
+++ b/Asterion/Services/Modrinth/ModrinthService.cs
@@ -311,7 +311,6 @@ public partial class ModrinthService
                 var result = new SearchResult<ProjectDto>(new ProjectDto()
                 {
                     Project = project,
-                    MajorColor = (await httpClient.GetMajorColorFromImageUrl(project.IconUrl)).ToDiscordColor(),
                     SearchResponse = searchResponse
                 }, SearchStatus.FoundById);
                 
@@ -337,7 +336,6 @@ public partial class ModrinthService
             var result = new SearchResult<ProjectDto>(new ProjectDto
             {
                 Project = project,
-                MajorColor = (await httpClient.GetMajorColorFromImageUrl(project.IconUrl)).ToDiscordColor(),
                 SearchResponse = searchResponse
             }, SearchStatus.FoundBySearch);
 

--- a/Asterion/Services/Modrinth/SearchResult.cs
+++ b/Asterion/Services/Modrinth/SearchResult.cs
@@ -29,7 +29,6 @@ public struct UserDto
 public struct ProjectDto
 {
     public Project Project;
-    public Discord.Color MajorColor;
     public SearchResponse? SearchResponse;
 }
 


### PR DESCRIPTION
Currently each search request calculated the color (which was cached for some time) but that task is computationally expensive to do for every request.

This pull request will use the colors for projects that Modrinth API provides.

No changes for User color, as Modrinth does not provide these.