### PR TITLE
Add option to change changelog style

### DIFF
--- a/Asterion/ComponentBuilders/SettingsComponentBuilder.cs
+++ b/Asterion/ComponentBuilders/SettingsComponentBuilder.cs
@@ -10,6 +10,7 @@ public static class SettingsComponentBuilder
     public const string MoreButtonId = "settings-module-more:*";
     public const string MainScreenButtonId = "settings-main:*";
     public const string ChangeMessageStyleSelectionId = "change-message-style:*";
+    public const string ChangeChangelogStyleSelectionId = "change-changelog-style:*";
     public static ComponentBuilder GetIntroButtons(string userId)
     {
         var components = 
@@ -89,6 +90,7 @@ public static class SettingsComponentBuilder
     {
         return new ComponentBuilder()
             .WithSelectMenu(GetMessageStyleSelection(guild, userId))
+            .WithSelectMenu(GetChangelogStyleSelection(guild, userId))
             .WithButton(GetBackButton(userId), 1);
     }
     public static SelectMenuBuilder GetMessageStyleSelection(Guild guild, string userId)
@@ -97,7 +99,8 @@ public static class SettingsComponentBuilder
         {
             MaxValues = 1,
             MinValues = 1,
-            CustomId = ChangeMessageStyleSelectionId.Replace("*", userId)
+            CustomId = ChangeMessageStyleSelectionId.Replace("*", userId),
+            Placeholder = "Select a message style"
         };
 
         var options = new List<SelectMenuOptionBuilder>();
@@ -111,6 +114,32 @@ public static class SettingsComponentBuilder
             });
         }
 
+        menu.Options = options;
+
+        return menu;
+    }
+
+    public static SelectMenuBuilder GetChangelogStyleSelection(Guild guild, string userId)
+    {
+        var menu = new SelectMenuBuilder
+        {
+            MaxValues = 1,
+            MinValues = 1,
+            CustomId = ChangeChangelogStyleSelectionId.Replace("*", userId),
+            Placeholder = "Select a changelog style"
+        };
+        
+        var options = new List<SelectMenuOptionBuilder>();
+        foreach (var style in Enum.GetValues(typeof(ChangelogStyle)).Cast<ChangelogStyle>())
+        {
+            options.Add(new SelectMenuOptionBuilder()
+            {
+                Label = Enum.GetName(typeof(ChangelogStyle), style),
+                Value = style.ToString(),
+                IsDefault = style == guild.GuildSettings.ChangelogStyle
+            });
+        }
+        
         menu.Options = options;
 
         return menu;

--- a/Asterion/Database/DataContext.cs
+++ b/Asterion/Database/DataContext.cs
@@ -44,6 +44,9 @@ namespace Asterion.Database
             modelBuilder.Entity<GuildSettings>().Property(p => p.ShowChannelSelection).HasDefaultValue(true);
             modelBuilder.Entity<GuildSettings>().Property(p => p.CheckMessagesForModrinthLink).HasDefaultValue(false);
             modelBuilder.Entity<GuildSettings>().Property(p => p.ShowSubscribeButton).HasDefaultValue(true);
+            modelBuilder.Entity<GuildSettings>().Property(p => p.MessageStyle).HasDefaultValue(MessageStyle.Full);
+            modelBuilder.Entity<GuildSettings>().Property(p => p.ChangelogStyle).HasDefaultValue(ChangelogStyle.PlainText);
+            modelBuilder.Entity<GuildSettings>().Property(p => p.ChangeLogMaxLength).HasDefaultValue(2000);
         }
     }
 }

--- a/Asterion/Database/Models/ChangelogStyle.cs
+++ b/Asterion/Database/Models/ChangelogStyle.cs
@@ -1,0 +1,8 @@
+namespace Asterion.Database.Models;
+
+public enum ChangelogStyle
+{
+    PlainText,
+    CodeBlock,
+    NoChangelog
+}

--- a/Asterion/Database/Models/GuildSettings.cs
+++ b/Asterion/Database/Models/GuildSettings.cs
@@ -30,4 +30,8 @@ public class GuildSettings
 
     public bool? CheckMessagesForModrinthLink { get; set; } = false;
     public MessageStyle MessageStyle { get; set; } = MessageStyle.Full;
+    
+    public ChangelogStyle ChangelogStyle { get; set; } = ChangelogStyle.PlainText;
+    
+    public long ChangeLogMaxLength { get; set; } = 2000;
 }

--- a/Asterion/EmbedBuilders/SettingsEmbedBuilder.cs
+++ b/Asterion/EmbedBuilders/SettingsEmbedBuilder.cs
@@ -64,7 +64,9 @@ public static class SettingsEmbedBuilder
 
         var dummyVersion = new Version()
         {
-            Changelog = "This would be the new version's changelog",
+            Changelog = "This is a changelog \n\n with multiple lines\n and a Markdown link [here](https://modrinth.com/)\n" +
+                        "and a style test: **bold**, *italic*, ~~strikethrough~~, `code`, __underline__\n" +
+                        "So that you can see how it looks like in the embed. 🐱",
             Id = "12456789",
             DatePublished = DateTime.Now,
             GameVersions = new[] {"1.19.2"},
@@ -74,7 +76,7 @@ public static class SettingsEmbedBuilder
             VersionNumber = "Version-3.5"
         };
 
-        var embed = ModrinthEmbedBuilder.VersionUpdateEmbed(guild.GuildSettings.MessageStyle, dummyProject, dummyVersion);
+        var embed = ModrinthEmbedBuilder.VersionUpdateEmbed(guild.GuildSettings, dummyProject, dummyVersion);
 
         return embed;
     }

--- a/Asterion/Migrations/20230223141738_addChangelogSettings.cs
+++ b/Asterion/Migrations/20230223141738_addChangelogSettings.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Asterion.Migrations
+{
+    /// <inheritdoc />
+    public partial class addChangelogSettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "MessageStyle",
+                table: "GuildSettings",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "INTEGER");
+
+            migrationBuilder.AddColumn<long>(
+                name: "ChangeLogMaxLength",
+                table: "GuildSettings",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 2000L);
+
+            migrationBuilder.AddColumn<int>(
+                name: "ChangelogStyle",
+                table: "GuildSettings",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ChangeLogMaxLength",
+                table: "GuildSettings");
+
+            migrationBuilder.DropColumn(
+                name: "ChangelogStyle",
+                table: "GuildSettings");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "MessageStyle",
+                table: "GuildSettings",
+                type: "INTEGER",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "INTEGER",
+                oldDefaultValue: 0);
+        }
+    }
+}

--- a/Asterion/Migrations/DataContextModelSnapshot.cs
+++ b/Asterion/Migrations/DataContextModelSnapshot.cs
@@ -15,7 +15,7 @@ namespace Asterion.Migrations
         protected override void BuildModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation("ProductVersion", "7.0.1");
+            modelBuilder.HasAnnotation("ProductVersion", "7.0.3");
 
             modelBuilder.Entity("Asterion.Database.Models.Array", b =>
                 {
@@ -73,6 +73,16 @@ namespace Asterion.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("INTEGER");
 
+                    b.Property<long>("ChangeLogMaxLength")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("INTEGER")
+                        .HasDefaultValue(2000L);
+
+                    b.Property<int>("ChangelogStyle")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("INTEGER")
+                        .HasDefaultValue(0);
+
                     b.Property<bool?>("CheckMessagesForModrinthLink")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("INTEGER")
@@ -82,7 +92,9 @@ namespace Asterion.Migrations
                         .HasColumnType("INTEGER");
 
                     b.Property<int>("MessageStyle")
-                        .HasColumnType("INTEGER");
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("INTEGER")
+                        .HasDefaultValue(0);
 
                     b.Property<bool?>("RemoveOnLeave")
                         .ValueGeneratedOnAdd()

--- a/Asterion/Modules/ModrinthModule.cs
+++ b/Asterion/Modules/ModrinthModule.cs
@@ -386,7 +386,9 @@ public class ModrinthModule : InteractionModuleBase<SocketInteractionContext>
 
                 var team = await _modrinthService.GetProjectsTeamMembersAsync(project.Id);
 
-                var embed = ModrinthEmbedBuilder.VersionUpdateEmbed(style, project, latestVersion, team);
+                var guild = await _dataService.GetGuildByIdAsync(Context.Guild.Id);
+
+                var embed = ModrinthEmbedBuilder.VersionUpdateEmbed(guild?.GuildSettings, project, latestVersion, team);
                 
                 var buttons =
                         new ComponentBuilder().WithButton(

--- a/Asterion/Services/DataService.cs
+++ b/Asterion/Services/DataService.cs
@@ -235,6 +235,8 @@ public class DataService : IDataService
         guild.GuildSettings.ShowChannelSelection = updatedGuild.GuildSettings.ShowChannelSelection;
         guild.GuildSettings.CheckMessagesForModrinthLink = updatedGuild.GuildSettings.CheckMessagesForModrinthLink;
         guild.GuildSettings.ShowSubscribeButton = updatedGuild.GuildSettings.ShowSubscribeButton;
+        guild.GuildSettings.ChangelogStyle = updatedGuild.GuildSettings.ChangelogStyle;
+        guild.GuildSettings.ChangeLogMaxLength = updatedGuild.GuildSettings.ChangeLogMaxLength;
 
         await db.SaveChangesAsync();
 

--- a/Asterion/Services/Modrinth/ModrinthService.cs
+++ b/Asterion/Services/Modrinth/ModrinthService.cs
@@ -203,7 +203,7 @@ public partial class ModrinthService
             _logger.LogInformation("Sending updates to guild ID {Id} and channel ID {Channel}", guild.GuildId, channel.Id);
 
             // None of these can be null, everything is checked beforehand
-            await SendUpdatesToChannel(channel, project, versions, teamMembers, guild.GuildSettings.MessageStyle);
+            await SendUpdatesToChannel(channel, project, versions, teamMembers, guild.GuildSettings);
         }
     }
 
@@ -214,13 +214,13 @@ public partial class ModrinthService
     /// <param name="currentProject"></param>
     /// <param name="newVersions"></param>
     /// <param name="team"></param>
-    /// <param name="messageStyle"></param>
-    private async Task SendUpdatesToChannel(SocketTextChannel textChannel, Project currentProject, IEnumerable<Version> newVersions, TeamMember[]? team, MessageStyle messageStyle = MessageStyle.Full)
+    /// <param name="guildSettings"></param>
+    private async Task SendUpdatesToChannel(SocketTextChannel textChannel, Project currentProject, IEnumerable<Version> newVersions, TeamMember[]? team, GuildSettings guildSettings)
     {
         // Iterate versions - they are ordered from latest to oldest, we want to sent them chronologically
         foreach (var version in newVersions.Reverse())
         {
-            var embed = ModrinthEmbedBuilder.VersionUpdateEmbed(messageStyle, currentProject, version, team);
+            var embed = ModrinthEmbedBuilder.VersionUpdateEmbed(guildSettings, currentProject, version, team);
             var buttons =
                 new ComponentBuilder().WithButton(
                     ModrinthComponentBuilder.GetVersionUrlButton(currentProject, version));


### PR DESCRIPTION
Currently with 3 options, plain text (default), code block and no changelog, also added dummy changelog to showcase how different Markdown formatting will look.

Everything is in `/settings` command