### PR TITLE
Make `/subscribe` and `/change-channel` commands list all available channels

### DIFF
--- a/Asterion.Test/Asterion.Test.csproj
+++ b/Asterion.Test/Asterion.Test.csproj
@@ -16,7 +16,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-        <PackageReference Include="Modrinth.Net" Version="3.1.0" />
+        <PackageReference Include="Modrinth.Net" Version="3.1.1" />
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
         <PackageReference Include="NUnit.Analyzers" Version="3.6.1">

--- a/Asterion.Test/Asterion.Test.csproj
+++ b/Asterion.Test/Asterion.Test.csproj
@@ -16,7 +16,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-        <PackageReference Include="Modrinth.Net" Version="3.1.0-rc3" />
+        <PackageReference Include="Modrinth.Net" Version="3.1.0" />
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
         <PackageReference Include="NUnit.Analyzers" Version="3.6.1">

--- a/Asterion/Asterion.csproj
+++ b/Asterion/Asterion.csproj
@@ -29,7 +29,7 @@
       <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0" />
-      <PackageReference Include="Modrinth.Net" Version="3.1.0-rc3" />
+      <PackageReference Include="Modrinth.Net" Version="3.1.1" />
       <PackageReference Include="Serilog" Version="2.12.0" />
       <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
       <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />

--- a/Asterion/AutocompleteHandlers/AnnouncementChannelPrecondition.cs
+++ b/Asterion/AutocompleteHandlers/AnnouncementChannelPrecondition.cs
@@ -9,13 +9,19 @@ namespace Asterion.AutocompleteHandlers;
 
 public class AnnouncementChannelPrecondition : ParameterPreconditionAttribute 
 {
-    public override async Task<PreconditionResult> CheckRequirementsAsync(IInteractionContext context, IParameterInfo parameterInfo, object value,
+    public override async Task<PreconditionResult> CheckRequirementsAsync(IInteractionContext context, IParameterInfo parameterInfo, object? value,
         IServiceProvider services)
     {
+        if (value is null)
+        {
+            // That's ok for us
+            return PreconditionResult.FromSuccess();
+        }
+
         // We need to check if the channel is a text channel, because we can't send messages to voice channels
         if (value is not SocketTextChannel channel)
         {
-            return PreconditionResult.FromError("Channel must allow sending messages");
+            return PreconditionResult.FromError("Channel must be a text channel");
         }
         
         // We need to check if the bot has permissions to send messages to the channel

--- a/Asterion/AutocompleteHandlers/AnnouncementChannelPrecondition.cs
+++ b/Asterion/AutocompleteHandlers/AnnouncementChannelPrecondition.cs
@@ -1,0 +1,30 @@
+using Discord;
+using Discord.Interactions;
+using Discord.WebSocket;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Serilog.Core;
+
+namespace Asterion.AutocompleteHandlers;
+
+public class AnnouncementChannelPrecondition : ParameterPreconditionAttribute 
+{
+    public override async Task<PreconditionResult> CheckRequirementsAsync(IInteractionContext context, IParameterInfo parameterInfo, object value,
+        IServiceProvider services)
+    {
+        // We need to check if the channel is a text channel, because we can't send messages to voice channels
+        if (value is not SocketTextChannel channel)
+        {
+            return PreconditionResult.FromError("Channel must allow sending messages");
+        }
+        
+        // We need to check if the bot has permissions to send messages to the channel
+        if (channel.Guild.CurrentUser.GetPermissions(channel).SendMessages == false)
+        {
+            return PreconditionResult.FromError("Bot doesn't have permissions to send messages to the channel");
+        }
+        
+        // All good
+        return PreconditionResult.FromSuccess();
+    }
+}

--- a/Asterion/Modules/ModrinthModule.cs
+++ b/Asterion/Modules/ModrinthModule.cs
@@ -169,12 +169,12 @@ public class ModrinthModule : InteractionModuleBase<SocketInteractionContext>
         [RequireUserPermission(GuildPermission.Administrator, Group = "ManageSubs")]
         [DoManageSubsRoleCheck(Group = "ManageSubs")]
         [SlashCommand("subscribe", "Add a Modrinth project to your watched list")]
-        public async Task Subscribe(string projectId, SocketTextChannel? customChannel = null)
+        public async Task Subscribe(string projectId, [AnnouncementChannelPrecondition] IGuildChannel? customChannel = null)
         {
                 await DeferAsync();
                 var project = await _modrinthService.GetProject(projectId);
 
-                var channel = customChannel ?? Context.Guild.GetTextChannel(Context.Channel.Id);
+                var channel = customChannel is null ? Context.Guild.GetTextChannel(Context.Channel.Id) : customChannel as ITextChannel;
                 
                 if (project == null)
                 {

--- a/Asterion/Modules/ModrinthModule.cs
+++ b/Asterion/Modules/ModrinthModule.cs
@@ -217,7 +217,7 @@ public class ModrinthModule : InteractionModuleBase<SocketInteractionContext>
         [SlashCommand("change-channel", "Change channel for one of your subscribed projects")]
         public async Task ChangeChannel(
                 [Summary("project_id"), Autocomplete(typeof(SubscribedIdAutocompletionHandler))] string projectId,
-                SocketTextChannel newChannel)
+                [AnnouncementChannelPrecondition] IGuildChannel newChannel)
         {
                 await DeferAsync();
                 
@@ -236,9 +236,10 @@ public class ModrinthModule : InteractionModuleBase<SocketInteractionContext>
 
                 if (success)
                 {
+                        var forMention = Context.Guild.GetTextChannel(newChannel.Id);
                         await ModifyOriginalResponseAsync(x =>
                         {
-                                x.Content = $"New updates for project {projectId} will be send to channel {newChannel.Mention} :white_check_mark:";
+                                x.Content = $"New updates for project {projectId} will be send to channel {forMention.Mention} :white_check_mark:";
                         });
                 }
                 else


### PR DESCRIPTION
This makes it so that `subscribe` and `change-channel` commands show all available channels and also checks if the bot can send message to that channel before subscribing.