### PR TITLE
Only check projects that were updated

### DIFF
--- a/Asterion/Interfaces/IDataService.cs
+++ b/Asterion/Interfaces/IDataService.cs
@@ -44,7 +44,7 @@ public interface IDataService
     /// </param>
     /// <param name="projectTitle">Title of the project, not required</param>
     /// <returns>If the operation was successful</returns>
-    public Task<bool> AddModrinthProjectToGuildAsync(ulong guildId, string projectId, string lastCheckVersion,
+    public Task<bool> AddModrinthProjectToGuildAsync(ulong guildId, string projectId, string lastCheckVersion, DateTime lastUpdate,
         ulong customChannelId, string? projectTitle = null);
 
     /// <summary>

--- a/Asterion/Modules/ModrinthInteractionModule.cs
+++ b/Asterion/Modules/ModrinthInteractionModule.cs
@@ -98,7 +98,7 @@ public class ModrinthInteractionModule : InteractionModuleBase
             x.Components = GetButtons(project, guild.GuildSettings, false, team).Build();
         });
 
-        await _dataService.AddModrinthProjectToGuildAsync(guildId, project.Id, latestVersion.Id, channel.Id,
+        await _dataService.AddModrinthProjectToGuildAsync(guildId, project.Id, latestVersion.Id, project.Updated, channel.Id,
             project.Title);
 
         await FollowupAsync(

--- a/Asterion/Modules/ModrinthModule.cs
+++ b/Asterion/Modules/ModrinthModule.cs
@@ -200,7 +200,7 @@ public class ModrinthModule : InteractionModuleBase<SocketInteractionContext>
             return;
         }
 
-        await _dataService.AddModrinthProjectToGuildAsync(Context.Guild.Id, project.Id, lastVersion, channel.Id,
+        await _dataService.AddModrinthProjectToGuildAsync(Context.Guild.Id, project.Id, lastVersion, project.Updated, channel.Id,
             project.Title);
 
         await ModifyOriginalResponseAsync(x =>

--- a/Asterion/Services/DataService.cs
+++ b/Asterion/Services/DataService.cs
@@ -142,7 +142,7 @@ public class DataService : IDataService
         return true;
     }
 
-    public async Task<bool> AddModrinthProjectToGuildAsync(ulong guildId, string projectId, string lastCheckVersion,
+    public async Task<bool> AddModrinthProjectToGuildAsync(ulong guildId, string projectId, string lastCheckVersion, DateTime lastUpdated,
         ulong customChannelId, string? projectTitle = null)
     {
         using var scope = _services.CreateScope();
@@ -165,7 +165,7 @@ public class DataService : IDataService
             {
                 ProjectId = projectId,
                 Created = DateTime.Now,
-                LastUpdated = DateTime.Now,
+                LastUpdated = lastUpdated,
                 LastCheckVersion = lastCheckVersion,
                 Title = projectTitle
             }).Entity;

--- a/Asterion/Services/Modrinth/ModrinthService.cs
+++ b/Asterion/Services/Modrinth/ModrinthService.cs
@@ -79,7 +79,6 @@ public partial class ModrinthService
             var databaseProjects = await _dataService.GetAllModrinthProjectsAsync();
 
             var projectIds = databaseProjects.Select(x => x.ProjectId);
-
             _logger.LogDebug("Getting multiple projects ({Count}) from Modrinth", databaseProjects.Count);
             var apiProjects = await GetMultipleProjects(projectIds);
 
@@ -88,6 +87,9 @@ public partial class ModrinthService
                 _logger.LogWarning("Could not get information from API, update search interrupted");
                 return;
             }
+            
+            // Remove projects which are not updated (last update timestamp is less or equal to the last update timestamp in database)
+            apiProjects = apiProjects.Where(x => databaseProjects.Any(y => y.ProjectId == x.Id && y.LastUpdated < x.Updated)).ToArray();
 
             _logger.LogDebug("Got {Count} projects", apiProjects.Length);
 

--- a/Asterion/Services/Modrinth/ModrinthService.cs
+++ b/Asterion/Services/Modrinth/ModrinthService.cs
@@ -96,7 +96,7 @@ public partial class ModrinthService
             var versions = apiProjects.SelectMany(p => p.Versions).ToArray();
 
 
-            const int splitBy = 500;
+            const int splitBy = 100;
             _logger.LogDebug("Getting multiple versions ({Count}) from Modrinth", versions.Length);
 
             // Make multiple requests to get all versions - we don't want to get 1500+ versions in one request


### PR DESCRIPTION
Currently we were checking every project, which was quite heavy on the API, this fixes it to only check projects that were updated